### PR TITLE
Fixing issue 41: Remove the enter event

### DIFF
--- a/src/app/components/dashboard/tables/finder/finder.component.html
+++ b/src/app/components/dashboard/tables/finder/finder.component.html
@@ -3,7 +3,7 @@
     <div fxLayout="row" fxLayoutAlign="space-between baseline">
       <h3>Filter</h3>
 
-      <button mat-button (click)="onClearFilter()">Clear filter</button>
+      <button mat-button (click)="onClearFilter()" type="button">Clear filter</button>
     </div>
 
     <mat-chip-list [ngStyle]="{ 'margin-bottom': '15px' }">


### PR DESCRIPTION
Fixes #41 

Updated the "Clear filter" button's type on finder tab to prevent accidently trigger when pressing enter